### PR TITLE
handle file/branch name collision in prj scan

### DIFF
--- a/script-project-manager/prj
+++ b/script-project-manager/prj
@@ -201,7 +201,7 @@ function check_git () {
         REMOTE=${branches[$LOCAL]}
         if [ "$REMOTE" == "__NULL" ]; then
             FOLLOW=": $MAGENTA$LOCAL$RESET does not track a remote"
-        elif ! git diff --quiet "$LOCAL" "$REMOTE"; then
+        elif ! git diff --quiet "$LOCAL" "$REMOTE" --; then
             FOLLOW=": $MAGENTA$LOCAL$RESET and $MAGENTA$REMOTE$RESET out of sync"
         else
             continue


### PR DESCRIPTION
add `--` to handle collision between branch and file names during prj scan 